### PR TITLE
Remove lifetimes from `Activation` struct

### DIFF
--- a/src/activations.rs
+++ b/src/activations.rs
@@ -1,27 +1,27 @@
 use std::f64::consts::E;
 
 #[derive(Clone)]
-pub struct Activation<'a> {
-	pub function: &'a dyn Fn(f64) -> f64,
-	pub derivative: &'a dyn Fn(f64) -> f64,
+pub struct Activation {
+	pub function: fn(f64) -> f64,
+	pub derivative: fn(f64) -> f64,
 }
 
 pub const IDENTITY: Activation = Activation {
-	function: &|x| x,
-	derivative: &|_| 1.0,
+	function: |x| x,
+	derivative: |_| 1.0,
 };
 
 pub const SIGMOID: Activation = Activation {
-	function: &|x| 1.0 / (1.0 + E.powf(-x)),
-	derivative: &|x| x * (1.0 - x),
+	function: |x| 1.0 / (1.0 + E.powf(-x)),
+	derivative: |x| x * (1.0 - x),
 };
 
 pub const TANH: Activation = Activation {
-	function: &|x| x.tanh(),
-	derivative: &|x| 1.0 - (x.powi(2)),
+	function: |x| x.tanh(),
+	derivative: |x| 1.0 - (x.powi(2)),
 };
 
 pub const RELU: Activation = Activation {
-	function: &|x| x.max(0.0),
-	derivative: &|x| if x > 0.0 { 1.0 } else { 0.0 },
+	function: |x| x.max(0.0),
+	derivative: |x| if x > 0.0 { 1.0 } else { 0.0 },
 };

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -107,7 +107,7 @@ impl Matrix {
 		res
 	}
 
-	pub fn map(&self, function: &dyn Fn(f64) -> f64) -> Matrix {
+	pub fn map(&self, function: impl Fn(f64) -> f64) -> Matrix {
 		Matrix::from(
 			(self.data)
 				.clone()

--- a/src/network.rs
+++ b/src/network.rs
@@ -8,13 +8,13 @@ use serde_json::{from_str, json};
 
 use super::{activations::Activation, matrix::Matrix};
 
-pub struct Network<'a> {
+pub struct Network {
 	layers: Vec<usize>,
 	weights: Vec<Matrix>,
 	biases: Vec<Matrix>,
 	data: Vec<Matrix>,
 	learning_rate: f64,
-	activation: Activation<'a>,
+	activation: Activation,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -23,12 +23,12 @@ struct SaveData {
 	biases: Vec<Vec<Vec<f64>>>,
 }
 
-impl Network<'_> {
-	pub fn new<'a>(
+impl Network {
+	pub fn new(
 		layers: Vec<usize>,
 		learning_rate: f64,
-		activation: Activation<'a>,
-	) -> Network<'a> {
+		activation: Activation,
+	) -> Network {
 		let mut weights = vec![];
 		let mut biases = vec![];
 


### PR DESCRIPTION
An alternative to #1 that is a bit more idiomatic 